### PR TITLE
Fix to allow setting of text property on CHANGE

### DIFF
--- a/src/feathers/controls/TextInput.hx
+++ b/src/feathers/controls/TextInput.hx
@@ -331,6 +331,9 @@ class TextInput extends FeathersControl implements IStateContext<TextInputState>
 			value = "";
 		}
 		if (this._text == value) {
+			if (this._text != textField.text){
+				this.setInvalid(DATA);
+			}
 			return this._text;
 		}
 		this._text = value;


### PR DESCRIPTION
Prior to this fix, you can not set the text property of an TextInput on the change event. I'm not sure if this is the right way, or rather, the way you want to deal with it, but I thought I'd toss in the PR anyway.