### PR TITLE
Support buttons at the root of a `MenuBar`.

### DIFF
--- a/src/feathers/controls/MenuBar.hx
+++ b/src/feathers/controls/MenuBar.hx
@@ -1572,7 +1572,7 @@ class MenuBar extends FeathersControl implements IDataSelector<Dynamic> implemen
 		var itemState = this.itemRendererToItemState.get(itemRenderer);
 		if (itemState.branch) {
 			this.openMenuAtIndex(itemState.index);
-		} else {
+		} else if (!itemState.separator && itemState.enabled) {
 			MenuEvent.dispatch(this, MenuEvent.ITEM_TRIGGER, itemState);
 		}
 	}


### PR DESCRIPTION
In the unlikely event that this happens, the user probably wants it to be a clickable menu button, not an empty menu. If they really do want an empty menu, they can pass `[]`, as documented in all the hierarchical collections.