### PR TITLE
Synchronize horizontal/vertical classes.

### DIFF
--- a/src/feathers/controls/HScrollBar.hx
+++ b/src/feathers/controls/HScrollBar.hx
@@ -125,7 +125,7 @@ class HScrollBar extends BaseScrollBar {
 		this._thumbStartY = y;
 	}
 
-	override function measure():Bool {
+	override private function measure():Bool {
 		var needsWidth = this.explicitWidth == null;
 		var needsHeight = this.explicitHeight == null;
 		var needsMinWidth = this.explicitMinWidth == null;

--- a/src/feathers/controls/HSlider.hx
+++ b/src/feathers/controls/HSlider.hx
@@ -77,6 +77,7 @@ class HSlider extends BaseSlider {
 
 	override private function locationToValue(x:Float, y:Float):Float {
 		var percentage = 0.0;
+
 		var trackScrollableWidth = this.actualWidth - this.minimumPadding - this.maximumPadding;
 		if (this._currentThumbSkin != null) {
 			trackScrollableWidth -= this._currentThumbSkin.width;
@@ -84,6 +85,7 @@ class HSlider extends BaseSlider {
 		var xOffset = x - this._pointerStartX - this.minimumPadding;
 		var xPosition = Math.min(Math.max(0.0, this._thumbStartX + xOffset), trackScrollableWidth);
 		percentage = xPosition / trackScrollableWidth;
+
 		return this._minimum + percentage * (this._maximum - this._minimum);
 	}
 
@@ -165,7 +167,7 @@ class HSlider extends BaseSlider {
 				if (newMinHeight < this._currentTrackSkin.height) {
 					newMinHeight = this._currentTrackSkin.height;
 				}
-				if (this._currentSecondaryTrackSkin != null && newHeight < this._currentSecondaryTrackSkin.height) {
+				if (this._currentSecondaryTrackSkin != null && newMinHeight < this._currentSecondaryTrackSkin.height) {
 					newMinHeight = this._currentSecondaryTrackSkin.height;
 				}
 			}

--- a/src/feathers/controls/VProgressBar.hx
+++ b/src/feathers/controls/VProgressBar.hx
@@ -201,6 +201,7 @@ class VProgressBar extends BaseProgressBar {
 			default:
 				throw new ArgumentError("Unknown fill mode: " + this.fillMode);
 		}
+
 		if ((this._currentFillSkin is IValidating)) {
 			(cast this._currentFillSkin : IValidating).validateNow();
 		}

--- a/src/feathers/controls/VScrollBar.hx
+++ b/src/feathers/controls/VScrollBar.hx
@@ -249,21 +249,21 @@ class VScrollBar extends BaseScrollBar {
 			maxTrackY -= this.incrementButton.height;
 		}
 
-		this._currentSecondaryTrackSkin.y = minTrackY;
-		this._currentSecondaryTrackSkin.height = location;
+		this._currentTrackSkin.y = minTrackY;
+		this._currentTrackSkin.height = location;
 
-		this._currentTrackSkin.y = location;
-		this._currentTrackSkin.height = maxTrackY - location;
+		this._currentSecondaryTrackSkin.y = location;
+		this._currentSecondaryTrackSkin.height = maxTrackY - location;
 
-		if ((this._currentSecondaryTrackSkin is IValidating)) {
-			(cast this._currentSecondaryTrackSkin : IValidating).validateNow();
-		}
 		if ((this._currentTrackSkin is IValidating)) {
 			(cast this._currentTrackSkin : IValidating).validateNow();
 		}
+		if ((this._currentSecondaryTrackSkin is IValidating)) {
+			(cast this._currentSecondaryTrackSkin : IValidating).validateNow();
+		}
 
-		this._currentSecondaryTrackSkin.x = (this.actualWidth - this._currentSecondaryTrackSkin.width) / 2.0;
 		this._currentTrackSkin.x = (this.actualWidth - this._currentTrackSkin.width) / 2.0;
+		this._currentSecondaryTrackSkin.x = (this.actualWidth - this._currentSecondaryTrackSkin.width) / 2.0;
 	}
 
 	override private function layoutSingleTrack():Void {

--- a/src/feathers/controls/VScrollBar.hx
+++ b/src/feathers/controls/VScrollBar.hx
@@ -249,11 +249,11 @@ class VScrollBar extends BaseScrollBar {
 			maxTrackY -= this.incrementButton.height;
 		}
 
-		this._currentTrackSkin.y = minTrackY;
-		this._currentTrackSkin.height = location;
+		this._currentSecondaryTrackSkin.y = minTrackY;
+		this._currentSecondaryTrackSkin.height = location;
 
-		this._currentSecondaryTrackSkin.y = location;
-		this._currentSecondaryTrackSkin.height = maxTrackY - location;
+		this._currentTrackSkin.y = location;
+		this._currentTrackSkin.height = maxTrackY - location;
 
 		if ((this._currentTrackSkin is IValidating)) {
 			(cast this._currentTrackSkin : IValidating).validateNow();

--- a/src/feathers/controls/VSlider.hx
+++ b/src/feathers/controls/VSlider.hx
@@ -196,21 +196,21 @@ class VSlider extends BaseSlider {
 			location += Math.round(this._currentThumbSkin.height / 2.0);
 		}
 
-		this._currentSecondaryTrackSkin.y = 0.0;
-		this._currentSecondaryTrackSkin.height = location;
+		this._currentTrackSkin.y = 0.0;
+		this._currentTrackSkin.height = location;
 
-		this._currentTrackSkin.y = location;
-		this._currentTrackSkin.height = this.actualHeight - location;
+		this._currentSecondaryTrackSkin.y = location;
+		this._currentSecondaryTrackSkin.height = this.actualHeight - location;
 
-		if ((this._currentSecondaryTrackSkin is IValidating)) {
-			(cast this._currentSecondaryTrackSkin : IValidating).validateNow();
-		}
 		if ((this._currentTrackSkin is IValidating)) {
 			(cast this._currentTrackSkin : IValidating).validateNow();
 		}
+		if ((this._currentSecondaryTrackSkin is IValidating)) {
+			(cast this._currentSecondaryTrackSkin : IValidating).validateNow();
+		}
 
-		this._currentSecondaryTrackSkin.x = (this.actualWidth - this._currentSecondaryTrackSkin.width) / 2.0;
 		this._currentTrackSkin.x = (this.actualWidth - this._currentTrackSkin.width) / 2.0;
+		this._currentSecondaryTrackSkin.x = (this.actualWidth - this._currentSecondaryTrackSkin.width) / 2.0;
 	}
 
 	override private function layoutSingleTrack():Void {

--- a/src/feathers/controls/VSlider.hx
+++ b/src/feathers/controls/VSlider.hx
@@ -196,11 +196,11 @@ class VSlider extends BaseSlider {
 			location += Math.round(this._currentThumbSkin.height / 2.0);
 		}
 
-		this._currentTrackSkin.y = 0.0;
-		this._currentTrackSkin.height = location;
+		this._currentSecondaryTrackSkin.y = 0.0;
+		this._currentSecondaryTrackSkin.height = location;
 
-		this._currentSecondaryTrackSkin.y = location;
-		this._currentSecondaryTrackSkin.height = this.actualHeight - location;
+		this._currentTrackSkin.y = location;
+		this._currentTrackSkin.height = this.actualHeight - location;
 
 		if ((this._currentTrackSkin is IValidating)) {
 			(cast this._currentTrackSkin : IValidating).validateNow();

--- a/src/feathers/layout/HDividedBoxLayout.hx
+++ b/src/feathers/layout/HDividedBoxLayout.hx
@@ -454,9 +454,9 @@ class HDividedBoxLayout extends EventDispatcher implements ILayout {
 				var percentWidth = 100.0;
 				if ((item is IMeasureObject)) {
 					var measureItem:IMeasureObject = cast item;
-					var columnExplicitMinWidth = measureItem.explicitMinWidth;
-					if (columnExplicitMinWidth != null) {
-						totalMinWidth += columnExplicitMinWidth;
+					var itemExplicitMinWidth = measureItem.explicitMinWidth;
+					if (itemExplicitMinWidth != null) {
+						totalMinWidth += itemExplicitMinWidth;
 					}
 				}
 				totalPercentWidth += percentWidth;
@@ -495,21 +495,21 @@ class HDividedBoxLayout extends EventDispatcher implements ILayout {
 				// round to nearest pixel so that there aren't any visual gaps
 				// between items. we'll append the remainder at the end.
 				var itemWidth = Math.ffloor(percentToPixels * percentWidth);
-				var columnMinWidth:Null<Float> = null;
+				var itemMinWidth:Null<Float> = null;
 				if ((item is IMeasureObject)) {
 					var measureItem:IMeasureObject = cast item;
-					columnMinWidth = measureItem.explicitMinWidth;
+					itemMinWidth = measureItem.explicitMinWidth;
 				}
 
-				if (columnMinWidth != null) {
-					if (columnMinWidth > remainingWidth) {
+				if (itemMinWidth != null) {
+					if (itemMinWidth > remainingWidth) {
 						// we try to respect the item's minimum width, but if
 						// it's larger than the remaining space, we need to
 						// force it to fit
-						columnMinWidth = remainingWidth;
+						itemMinWidth = remainingWidth;
 					}
-					if (itemWidth < columnMinWidth) {
-						itemWidth = columnMinWidth;
+					if (itemWidth < itemMinWidth) {
+						itemWidth = itemMinWidth;
 						remainingWidth -= itemWidth;
 						totalPercentWidth -= percentWidth;
 						pendingIndices.remove(index);

--- a/src/feathers/layout/HorizontalDistributedLayout.hx
+++ b/src/feathers/layout/HorizontalDistributedLayout.hx
@@ -509,7 +509,7 @@ class HorizontalDistributedLayout extends EventDispatcher implements ILayout imp
 			item.width = itemWidth;
 			if ((item is IValidating)) {
 				// changing the width of the item may cause its height
-				// to change, so we need to validate. the height is
+				// to change, so we need to validate. the width is
 				// needed for measurement.
 				(cast item : IValidating).validateNow();
 			}

--- a/src/feathers/layout/HorizontalLayout.hx
+++ b/src/feathers/layout/HorizontalLayout.hx
@@ -184,6 +184,9 @@ class HorizontalLayout extends EventDispatcher implements ILayout implements IDr
 
 		@default 0.0
 
+		@see `HorizontalLayoutData.marginLeft`
+		@see `HorizontalLayoutData.marginRight`
+
 		@since 1.0.0
 	**/
 	@:bindable("change")

--- a/src/feathers/layout/HorizontalLayoutData.hx
+++ b/src/feathers/layout/HorizontalLayoutData.hx
@@ -89,7 +89,7 @@ class HorizontalLayoutData extends EventDispatcher implements ILayoutData {
 		container.layout = new HorizontalLayout();
 
 		var child = new Label();
-		child.layoutData = HorizontalLayoutData.fillHorizontal();
+		child.layoutData = HorizontalLayoutData.fillVertical();
 		container.addChild(child);
 		```
 

--- a/src/feathers/layout/HorizontalListLayout.hx
+++ b/src/feathers/layout/HorizontalListLayout.hx
@@ -141,7 +141,7 @@ class HorizontalListLayout extends EventDispatcher implements IVirtualLayout imp
 		layout.requestedColumnCount = 2.0;
 		```
 
-		@default 5.0
+		@default null
 
 		@since 1.0.0
 	**/
@@ -169,7 +169,7 @@ class HorizontalListLayout extends EventDispatcher implements IVirtualLayout imp
 
 		If `requestedColumnCount` is also set, this property is ignored.
 
-		In the following example, the layout's requested minimum coumn count is
+		In the following example, the layout's requested minimum column count is
 		set to 2 complete items:
 
 		```haxe
@@ -814,7 +814,7 @@ class HorizontalListLayout extends EventDispatcher implements IVirtualLayout imp
 			estimatedItemWidth = this._typicalItem.width;
 			// it's possible for two separate items to both be partially
 			// visible in the view port, so ceil alone may not be enough
-			minItems = Math.ceil(width / (estimatedItemWidth) + adjustedGap) + 1;
+			minItems = Math.ceil(width / (estimatedItemWidth + adjustedGap)) + 1;
 		}
 		var positionX = this._paddingLeft;
 		var scrollX = this._scrollX;
@@ -835,9 +835,9 @@ class HorizontalListLayout extends EventDispatcher implements IVirtualLayout imp
 				itemWidth = cacheItem.itemWidth;
 				if (estimatedItemWidth == null) {
 					estimatedItemWidth = itemWidth;
-					minItems = Math.ceil(width / (estimatedItemWidth) + adjustedGap) + 1;
+					minItems = Math.ceil(width / (estimatedItemWidth + adjustedGap)) + 1;
 					if (skippedMissingItems > 0) {
-						// include the heights of any items that were missing
+						// include the widths of any items that were missing
 						for (j in 0...skippedMissingItems) {
 							positionX += estimatedItemWidth + adjustedGap;
 							if (startIndex == -1 && positionX >= scrollX) {
@@ -866,7 +866,7 @@ class HorizontalListLayout extends EventDispatcher implements IVirtualLayout imp
 					skippedMissingItems++;
 					continue;
 				}
-				// if we can't find an estimated height, we return a range
+				// if we can't find an estimated width, we return a range
 				// where only the first item is visible. this allows the
 				// first item to be measured, and the container can
 				// request the visible items again using that measurement
@@ -889,7 +889,7 @@ class HorizontalListLayout extends EventDispatcher implements IVirtualLayout imp
 			}
 		}
 		if (startIndex == -1 && this._horizontalAlign != LEFT) {
-			// if we're not aligned to the top, scrolling beyond the end might
+			// if we're not aligned to the left, scrolling beyond the end might
 			// make some items disappear prematurely, so back-fill from here
 			startIndex = itemCount - 1;
 			endIndex = startIndex;
@@ -908,7 +908,7 @@ class HorizontalListLayout extends EventDispatcher implements IVirtualLayout imp
 					itemWidth = cacheItem.itemWidth;
 					if (estimatedItemWidth == null) {
 						estimatedItemWidth = itemWidth;
-						minItems = Math.ceil(width / (estimatedItemWidth) + adjustedGap) + 1;
+						minItems = Math.ceil(width / (estimatedItemWidth + adjustedGap)) + 1;
 					}
 				} else if (estimatedItemWidth != null) {
 					itemWidth = estimatedItemWidth;

--- a/src/feathers/layout/VDividedBoxLayout.hx
+++ b/src/feathers/layout/VDividedBoxLayout.hx
@@ -293,8 +293,8 @@ class VDividedBoxLayout extends EventDispatcher implements ILayout {
 				divider.y = contentHeight;
 				contentHeight += divider.height;
 			}
-			// the height might have changed after the initial validation
 			if ((item is IValidating)) {
+				// the height might have changed after the initial validation
 				(cast item : IValidating).validateNow();
 			}
 			if (contentWidth < item.width) {
@@ -455,9 +455,9 @@ class VDividedBoxLayout extends EventDispatcher implements ILayout {
 				var percentHeight = 100.0;
 				if ((item is IMeasureObject)) {
 					var measureItem:IMeasureObject = cast item;
-					var columnExplicitMinHeight = measureItem.explicitMinHeight;
-					if (columnExplicitMinHeight != null) {
-						totalMinHeight += columnExplicitMinHeight;
+					var itemExplicitMinHeight = measureItem.explicitMinHeight;
+					if (itemExplicitMinHeight != null) {
+						totalMinHeight += itemExplicitMinHeight;
 					}
 				}
 				totalPercentHeight += percentHeight;
@@ -496,21 +496,21 @@ class VDividedBoxLayout extends EventDispatcher implements ILayout {
 				// round to nearest pixel so that there aren't any visual gaps
 				// between items. we'll append the remainder at the end.
 				var itemHeight = Math.ffloor(percentToPixels * percentHeight);
-				var columnMinHeight:Null<Float> = null;
+				var itemMinHeight:Null<Float> = null;
 				if ((item is IMeasureObject)) {
 					var measureItem:IMeasureObject = cast item;
-					columnMinHeight = measureItem.explicitMinHeight;
+					itemMinHeight = measureItem.explicitMinHeight;
 				}
 
-				if (columnMinHeight != null) {
-					if (columnMinHeight > remainingHeight) {
+				if (itemMinHeight != null) {
+					if (itemMinHeight > remainingHeight) {
 						// we try to respect the item's minimum height, but if
 						// it's larger than the remaining space, we need to
 						// force it to fit
-						columnMinHeight = remainingHeight;
+						itemMinHeight = remainingHeight;
 					}
-					if (itemHeight < columnMinHeight) {
-						itemHeight = columnMinHeight;
+					if (itemHeight < itemMinHeight) {
+						itemHeight = itemMinHeight;
 						remainingHeight -= itemHeight;
 						totalPercentHeight -= percentHeight;
 						pendingIndices.remove(index);
@@ -533,7 +533,7 @@ class VDividedBoxLayout extends EventDispatcher implements ILayout {
 			}
 		} while (needsAnotherPass);
 		if (remainingHeight > 0.0 && pendingIndices.length > 0) {
-			// minimize the impact of a non-integer width by adding the
+			// minimize the impact of a non-integer height by adding the
 			// remainder to the final item
 			var index = pendingIndices[pendingIndices.length - 1];
 			var finalItem = items[index];

--- a/src/feathers/layout/VerticalAlign.hx
+++ b/src/feathers/layout/VerticalAlign.hx
@@ -43,7 +43,7 @@ enum VerticalAlign {
 	BOTTOM;
 
 	/**
-		The items in the layout will fill the height of the bounds.
+		The items in the layout will fill the height of the container bounds.
 
 		@since 1.0.0
 	**/

--- a/src/feathers/layout/VerticalDistributedLayout.hx
+++ b/src/feathers/layout/VerticalDistributedLayout.hx
@@ -337,7 +337,6 @@ class VerticalDistributedLayout extends EventDispatcher implements ILayout imple
 			item.y = contentHeight;
 			contentHeight += item.height + this._gap;
 		}
-		var maxItemWidth = contentWidth;
 		contentWidth += this._paddingLeft + this._paddingRight;
 		contentHeight += this._paddingBottom;
 		if (items.length > 0) {
@@ -365,7 +364,7 @@ class VerticalDistributedLayout extends EventDispatcher implements ILayout imple
 			}
 		}
 
-		this.applyHorizontalAlign(items, maxItemWidth, viewPortWidth);
+		this.applyHorizontalAlign(items, viewPortWidth);
 
 		if (contentWidth < viewPortWidth) {
 			contentWidth = viewPortWidth;
@@ -517,7 +516,7 @@ class VerticalDistributedLayout extends EventDispatcher implements ILayout imple
 		}
 	}
 
-	private inline function applyHorizontalAlign(items:Array<DisplayObject>, maxItemWidth:Float, viewPortWidth:Float):Void {
+	private inline function applyHorizontalAlign(items:Array<DisplayObject>, viewPortWidth:Float):Void {
 		var justifyContentWidth = viewPortWidth - this._paddingLeft - this._paddingRight;
 		if (justifyContentWidth < 0.0) {
 			justifyContentWidth = 0.0;

--- a/src/feathers/layout/VerticalLayout.hx
+++ b/src/feathers/layout/VerticalLayout.hx
@@ -349,14 +349,14 @@ class VerticalLayout extends EventDispatcher implements ILayout implements IDrag
 
 	/**
 		Indicates if the width of items should be reset for re-measurement if
-		the item has `HorizontalLayoutData` with the `percentWidth` property
+		the item has `VerticalLayoutData` with the `percentWidth` property
 		populated and the container's width is not explicitly set.
 
 		Useful if changes to the items' content might affect their measured
 		dimensions after applying the percentages. For instance, if changing a
 		component's text should cause it to resize.
 
-		@see `HorizontalLayoutData.percentWidth`
+		@see `VerticalLayoutData.percentWidth`
 
 		@since 1.0.0
 	**/
@@ -380,14 +380,14 @@ class VerticalLayout extends EventDispatcher implements ILayout implements IDrag
 
 	/**
 		Indicates if the height of items should be reset for re-measurement if
-		the item has `HorizontalLayoutData` with the `percentHeight` property
+		the item has `VerticalLayoutData` with the `percentHeight` property
 		populated and the container's height is not explicitly set.
 
 		Useful if changes to the items' content might affect their measured
 		dimensions after applying the percentages. For instance, if changing a
 		component's text should cause it to resize.
 
-		@see `HorizontalLayoutData.percentHeight`
+		@see `VerticalLayoutData.percentHeight`
 
 		@since 1.0.0
 	**/

--- a/src/feathers/layout/VerticalLayoutData.hx
+++ b/src/feathers/layout/VerticalLayoutData.hx
@@ -89,7 +89,7 @@ class VerticalLayoutData extends EventDispatcher implements ILayoutData {
 		container.layout = new VerticalLayout();
 
 		var child = new Label();
-		child.layoutData = VerticalLayoutData.fillHorizontal();
+		child.layoutData = VerticalLayoutData.fillVertical();
 		container.addChild(child);
 		```
 
@@ -220,7 +220,7 @@ class VerticalLayoutData extends EventDispatcher implements ILayoutData {
 		This item's `marginTop` value will be added to the layout's `gap`
 		value and the previous item's `marginBottom` value to create the total
 		space between items. If this is the first item in the layout, nothing
-		will be added to the `marginTop` value.
+		will be added to this item's `marginTop` value.
 
 		Negative values are allowed for the margins.
 

--- a/src/feathers/layout/VerticalListLayout.hx
+++ b/src/feathers/layout/VerticalListLayout.hx
@@ -645,9 +645,13 @@ class VerticalListLayout extends EventDispatcher implements IVirtualLayout imple
 				viewPortHeight = this._paddingTop + this._paddingBottom + ((this._requestedRowCount * (virtualRowHeight + adjustedGap)) - adjustedGap);
 			} else {
 				if (this._requestedMinRowCount != null && items.length < this._requestedMinRowCount) {
-					viewPortHeight = this._paddingTop + this._paddingBottom + ((this._requestedMinRowCount * (virtualRowHeight + adjustedGap)) - adjustedGap);
+					viewPortHeight = this._paddingTop
+						+ this._paddingBottom
+						+ ((this._requestedMinRowCount * (virtualRowHeight + adjustedGap)) - adjustedGap);
 				} else if (this._requestedMaxRowCount != null && items.length > this._requestedMaxRowCount) {
-					viewPortHeight = this._paddingTop + this._paddingBottom + ((this._requestedMaxRowCount * (virtualRowHeight + adjustedGap)) - adjustedGap);
+					viewPortHeight = this._paddingTop
+						+ this._paddingBottom
+						+ ((this._requestedMaxRowCount * (virtualRowHeight + adjustedGap)) - adjustedGap);
 				}
 			}
 			if (measurements.minHeight != null && viewPortHeight < measurements.minHeight) {
@@ -665,7 +669,9 @@ class VerticalListLayout extends EventDispatcher implements IVirtualLayout imple
 		result.contentWidth = itemWidth + this._paddingLeft + this._paddingRight;
 		result.contentHeight = positionY;
 		if (this._requestedMinRowCount != null) {
-			result.contentMinHeight = this._paddingTop + this._paddingBottom + ((this._requestedMinRowCount * (virtualRowHeight + adjustedGap)) - adjustedGap);
+			result.contentMinHeight = this._paddingTop
+				+ this._paddingBottom
+				+ ((this._requestedMinRowCount * (virtualRowHeight + adjustedGap)) - adjustedGap);
 		}
 		result.viewPortWidth = viewPortWidth;
 		result.viewPortHeight = viewPortHeight;

--- a/src/feathers/skins/VerticalLineSkin.hx
+++ b/src/feathers/skins/VerticalLineSkin.hx
@@ -91,7 +91,7 @@ class VerticalLineSkin extends BaseGraphicsPathSkin {
 	private var _paddingBottom:Float = 0.0;
 
 	/**
-		Empty space above the vertical line.
+		Empty space below the vertical line.
 
 		@since 1.1.0
 	**/


### PR DESCRIPTION
Using a tool I wrote, I found several inconsistencies in the "Horizontal" and "Vertical" classes.

These range from meaningless (e.g., line order) to inaccurate documentation (e.g., a default being listed as 5.0 when it's null) to possible errors (e.g., [adding `adjustedGap`](https://github.com/feathersui/feathersui-openfl/blob/433713b067eae5018104ee9ee7b345024a419661/src/feathers/layout/HorizontalListLayout.hx#L817) instead of [dividing by it](https://github.com/feathersui/feathersui-openfl/blob/433713b067eae5018104ee9ee7b345024a419661/src/feathers/layout/VerticalListLayout.hx#L812)).