### PR TITLE
Remove duplicate code in hierarchical collections.

### DIFF
--- a/src/feathers/data/ArrayHierarchicalCollection.hx
+++ b/src/feathers/data/ArrayHierarchicalCollection.hx
@@ -230,16 +230,15 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 		if (location == null || location.length == 0) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
+		var index = location[location.length - 1];
 		if (this._filterAndSortData != null) {
 			var branchChildren = this.findBranchChildren(this._filterAndSortData, this.filterAndSortDataItemToChildren, location);
-			var index = location[location.length - 1];
 			if (index < 0 || index >= branchChildren.length) {
 				throw new RangeError('Item not found at location: ${location}');
 			}
 			return branchChildren[index].item;
 		}
 		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
-		var index = location[location.length - 1];
 		if (index < 0 || index >= branchChildren.length) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
@@ -256,9 +255,9 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 		if (location == null || location.length == 0) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
+		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
+		var lastLocationIndex = location[location.length - 1];
 		if (this._filterAndSortData != null) {
-			var lastLocationIndex = location[location.length - 1];
-			var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, this.filterAndSortDataItemToChildren, location);
 			var oldItem:T = null;
 			var unfilteredLastLocationIndex = branchChildren.length;
@@ -300,13 +299,11 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 			}
 			return;
 		}
-		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
-		var index = location[location.length - 1];
-		if (index < 0 || index > branchChildren.length) {
+		if (lastLocationIndex < 0 || lastLocationIndex > branchChildren.length) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
-		var oldValue = branchChildren[index];
-		branchChildren[index] = value;
+		var oldValue = branchChildren[lastLocationIndex];
+		branchChildren[lastLocationIndex] = value;
 		HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.REPLACE_ITEM, location, value, oldValue);
 		FeathersEvent.dispatch(this, Event.CHANGE);
 	}
@@ -359,9 +356,9 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 		if (location == null || location.length == 0) {
 			throw new RangeError('Item cannot be added at location: ${location}');
 		}
+		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
+		var lastLocationIndex = location[location.length - 1];
 		if (this._filterAndSortData != null) {
-			var lastLocationIndex = location[location.length - 1];
-			var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, filterAndSortDataItemToChildren, location);
 			var oldItem:T = null;
 			var unfilteredLastLocationIndex = branchChildren.length;
@@ -389,12 +386,10 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 			}
 			return;
 		}
-		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
-		var index = location[location.length - 1];
-		if (index < 0 || index > branchChildren.length) {
+		if (lastLocationIndex < 0 || lastLocationIndex > branchChildren.length) {
 			throw new RangeError('Item cannot be added at location: ${location}');
 		}
-		branchChildren.insert(index, itemToAdd);
+		branchChildren.insert(lastLocationIndex, itemToAdd);
 		HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.ADD_ITEM, location, itemToAdd);
 		FeathersEvent.dispatch(this, Event.CHANGE);
 	}
@@ -409,9 +404,9 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 		if (location == null || location.length == 0) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
+		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
+		var lastLocationIndex = location[location.length - 1];
 		if (this._filterAndSortData != null) {
-			var lastLocationIndex = location[location.length - 1];
-			var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, filterAndSortDataItemToChildren, location);
 			var removedItem = filteredOrSortedBranchChildren.splice(lastLocationIndex, 1)[0].item;
 			branchChildren.remove(removedItem);
@@ -419,12 +414,10 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 			FeathersEvent.dispatch(this, Event.CHANGE);
 			return removedItem;
 		}
-		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
-		var index = location[location.length - 1];
-		if (index < 0 || index >= branchChildren.length) {
+		if (lastLocationIndex < 0 || lastLocationIndex >= branchChildren.length) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
-		var removedItem = branchChildren[index];
+		var removedItem = branchChildren[lastLocationIndex];
 		branchChildren.remove(removedItem);
 		HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.REMOVE_ITEM, location, null, removedItem);
 		FeathersEvent.dispatch(this, Event.CHANGE);
@@ -474,28 +467,17 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 		if (getLength(location) == 0) {
 			return;
 		}
+		var firstChildLocation = location.copy();
+		firstChildLocation.push(0);
+		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, firstChildLocation);
 		if (this._filterAndSortData != null) {
-			var firstChildLocation = location.copy();
-			firstChildLocation.push(0);
-			var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, firstChildLocation);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, filterAndSortDataItemToChildren, firstChildLocation);
 			#if (hl && haxe_ver < 4.3)
 			filteredOrSortedBranchChildren.splice(0, filteredOrSortedBranchChildren.length);
 			#else
 			filteredOrSortedBranchChildren.resize(0);
 			#end
-			#if (hl && haxe_ver < 4.3)
-			branchChildren.splice(0, branchChildren.length);
-			#else
-			branchChildren.resize(0);
-			#end
-			HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.REMOVE_ALL, location);
-			FeathersEvent.dispatch(this, Event.CHANGE);
-			return;
 		}
-		var firstChildLocation = location.copy();
-		firstChildLocation.push(0);
-		var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, firstChildLocation);
 		#if (hl && haxe_ver < 4.3)
 		branchChildren.splice(0, branchChildren.length);
 		#else

--- a/src/feathers/data/TreeCollection.hx
+++ b/src/feathers/data/TreeCollection.hx
@@ -240,9 +240,9 @@ class TreeCollection<T> extends EventDispatcher implements IHierarchicalCollecti
 		if (location == null || location.length == 0) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
+		var branchChildren = this.findBranchChildren(this._array, location);
+		var lastLocationIndex = location[location.length - 1];
 		if (this._filterAndSortData != null) {
-			var lastLocationIndex = location[location.length - 1];
-			var branchChildren = this.findBranchChildren(this._array, location);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, location);
 			var oldItem:TreeNode<T> = null;
 			var unfilteredLastLocationIndex = branchChildren.length;
@@ -284,13 +284,11 @@ class TreeCollection<T> extends EventDispatcher implements IHierarchicalCollecti
 			}
 			return;
 		}
-		var branchChildren = this.findBranchChildren(this._array, location);
-		var index = location[location.length - 1];
-		if (index < 0 || index > branchChildren.length) {
+		if (lastLocationIndex < 0 || lastLocationIndex > branchChildren.length) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
-		var oldValue = branchChildren[index];
-		branchChildren[index] = value;
+		var oldValue = branchChildren[lastLocationIndex];
+		branchChildren[lastLocationIndex] = value;
 		HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.REPLACE_ITEM, location, value, oldValue);
 		FeathersEvent.dispatch(this, Event.CHANGE);
 	}
@@ -342,9 +340,9 @@ class TreeCollection<T> extends EventDispatcher implements IHierarchicalCollecti
 		if (location == null || location.length == 0) {
 			throw new RangeError('Item cannot be added at location: ${location}');
 		}
+		var branchChildren = this.findBranchChildren(this._array, location);
+		var lastLocationIndex = location[location.length - 1];
 		if (this._filterAndSortData != null) {
-			var lastLocationIndex = location[location.length - 1];
-			var branchChildren = this.findBranchChildren(this._array, location);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, location);
 			var oldItem:TreeNode<T> = null;
 			var unfilteredLastLocationIndex = branchChildren.length;
@@ -372,12 +370,10 @@ class TreeCollection<T> extends EventDispatcher implements IHierarchicalCollecti
 			}
 			return;
 		}
-		var branchChildren = this.findBranchChildren(this._array, location);
-		var index = location[location.length - 1];
-		if (index < 0 || index > branchChildren.length) {
+		if (lastLocationIndex < 0 || lastLocationIndex > branchChildren.length) {
 			throw new RangeError('Item cannot be added at location: ${location}');
 		}
-		branchChildren.insert(index, itemToAdd);
+		branchChildren.insert(lastLocationIndex, itemToAdd);
 		HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.ADD_ITEM, location, itemToAdd);
 		FeathersEvent.dispatch(this, Event.CHANGE);
 	}
@@ -392,9 +388,9 @@ class TreeCollection<T> extends EventDispatcher implements IHierarchicalCollecti
 		if (location == null || location.length == 0) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
+		var branchChildren = this.findBranchChildren(this._array, location);
+		var lastLocationIndex = location[location.length - 1];
 		if (this._filterAndSortData != null) {
-			var lastLocationIndex = location[location.length - 1];
-			var branchChildren = this.findBranchChildren(this._array, location);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, location);
 			var removedItem = filteredOrSortedBranchChildren.splice(lastLocationIndex, 1)[0].item;
 			branchChildren.remove(removedItem);
@@ -402,12 +398,10 @@ class TreeCollection<T> extends EventDispatcher implements IHierarchicalCollecti
 			FeathersEvent.dispatch(this, Event.CHANGE);
 			return removedItem;
 		}
-		var branchChildren = this.findBranchChildren(this._array, location);
-		var index = location[location.length - 1];
-		if (index < 0 || index >= branchChildren.length) {
+		if (lastLocationIndex < 0 || lastLocationIndex >= branchChildren.length) {
 			throw new RangeError('Item not found at location: ${location}');
 		}
-		var removedItem = branchChildren[index];
+		var removedItem = branchChildren[lastLocationIndex];
 		branchChildren.remove(removedItem);
 		HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.REMOVE_ITEM, location, null, removedItem);
 		FeathersEvent.dispatch(this, Event.CHANGE);
@@ -457,28 +451,17 @@ class TreeCollection<T> extends EventDispatcher implements IHierarchicalCollecti
 		if (getLength(location) == 0) {
 			return;
 		}
+		var firstChildLocation = location.copy();
+		firstChildLocation.push(0);
+		var branchChildren = this.findBranchChildren(this._array, firstChildLocation);
 		if (this._filterAndSortData != null) {
-			var firstChildLocation = location.copy();
-			firstChildLocation.push(0);
-			var branchChildren = this.findBranchChildren(this._array, firstChildLocation);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, firstChildLocation);
 			#if (hl && haxe_ver < 4.3)
 			filteredOrSortedBranchChildren.splice(0, filteredOrSortedBranchChildren.length);
 			#else
 			filteredOrSortedBranchChildren.resize(0);
 			#end
-			#if (hl && haxe_ver < 4.3)
-			branchChildren.splice(0, branchChildren.length);
-			#else
-			branchChildren.resize(0);
-			#end
-			HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.REMOVE_ALL, location);
-			FeathersEvent.dispatch(this, Event.CHANGE);
-			return;
 		}
-		var firstChildLocation = location.copy();
-		firstChildLocation.push(0);
-		var branchChildren = this.findBranchChildren(this._array, firstChildLocation);
 		#if (hl && haxe_ver < 4.3)
 		branchChildren.splice(0, branchChildren.length);
 		#else


### PR DESCRIPTION
Because shorter functions are easier to read. I tried to only remove lines that exactly matched, not things like `TreeCollection.getLength()` that look like duplicate code but actually operate on different types.