### PR TITLE
Fix exception in `ArrayHierarchicalCollection.set()` when parent branch is filtered.

### DIFF
--- a/src/feathers/data/ArrayHierarchicalCollection.hx
+++ b/src/feathers/data/ArrayHierarchicalCollection.hx
@@ -711,12 +711,11 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 }
 
 private class FilterAndSortItem<T> {
-	public function new(item:T, ?children:Array<FilterAndSortItem<T>>, ?originalChildren:Array<T>) {
+	public function new(item:T) {
 		this.item = item;
-		this.children = children;
 	}
 
 	public var item:T;
-	public var children:Array<FilterAndSortItem<T>>;
-	public var originalChildren:Array<T>;
+	public var children:Array<FilterAndSortItem<T>> = null;
+	public var originalChildren:Array<T> = null;
 }

--- a/src/feathers/data/ArrayHierarchicalCollection.hx
+++ b/src/feathers/data/ArrayHierarchicalCollection.hx
@@ -259,8 +259,11 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 		if (this._filterAndSortData != null) {
 			var lastLocationIndex = location[location.length - 1];
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, this.filterAndSortDataItemToChildren, location);
-			var branchChildren = this.findBranchChildren(this._filterAndSortData, this.filterAndSortDataItemToChildren, location.slice(0, location.length - 1))
-				[location[location.length - 2]].originalChildren;
+			var branchChildren = this._array;
+			if (location.length >= 2) {
+				this.findBranchChildren(this._filterAndSortData, this.filterAndSortDataItemToChildren, location.slice(0, location.length - 1))
+					[location[location.length - 2]].originalChildren;
+			}
 			var oldItem:T = null;
 			var unfilteredLastLocationIndex = branchChildren.length;
 			if (lastLocationIndex < filteredOrSortedBranchChildren.length) {

--- a/src/feathers/data/ArrayHierarchicalCollection.hx
+++ b/src/feathers/data/ArrayHierarchicalCollection.hx
@@ -258,8 +258,9 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 		}
 		if (this._filterAndSortData != null) {
 			var lastLocationIndex = location[location.length - 1];
-			var branchChildren = this.findBranchChildren(this._array, this._itemToChildren, location);
 			var filteredOrSortedBranchChildren = this.findBranchChildren(this._filterAndSortData, this.filterAndSortDataItemToChildren, location);
+			var branchChildren = this.findBranchChildren(this._filterAndSortData, this.filterAndSortDataItemToChildren, location.slice(0, location.length - 1))
+				[location[location.length - 2]].originalChildren;
 			var oldItem:T = null;
 			var unfilteredLastLocationIndex = branchChildren.length;
 			if (lastLocationIndex < filteredOrSortedBranchChildren.length) {
@@ -674,6 +675,7 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 			var children = (this._itemToChildren != null) ? this._itemToChildren(item) : null;
 			if (children != null) {
 				result.children = [];
+				result.originalChildren = children;
 				this.refreshFilterAndSortInternal(children, result.children);
 			}
 		}
@@ -706,11 +708,12 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 }
 
 private class FilterAndSortItem<T> {
-	public function new(item:T, ?children:Array<FilterAndSortItem<T>>) {
+	public function new(item:T, ?children:Array<FilterAndSortItem<T>>, ?originalChildren:Array<T>) {
 		this.item = item;
 		this.children = children;
 	}
 
 	public var item:T;
 	public var children:Array<FilterAndSortItem<T>>;
+	public var originalChildren:Array<T>;
 }


### PR DESCRIPTION
Without this, the following will crash because it can't find the original item.

```haxe
final collection:ArrayHierarchicalCollection<TreeNode<Int>>
	= new ArrayHierarchicalCollection<TreeNode<Int>>([
	new TreeNode<Int>(1, [new TreeNode(1), new TreeNode(0), new TreeNode(2)]),
	new TreeNode<Int>(0, [new TreeNode(3), new TreeNode(3), new TreeNode(4)]),
	new TreeNode<Int>(5, [new TreeNode(0), new TreeNode(0), new TreeNode(1), new TreeNode(5)])
], (node:TreeNode<Int>) -> node.children);

trace(collection.get([0, 1]).data + " == " + 0);
trace(collection.get([1, 1]).data + " == " + 3);

collection.filterFunction = (node:TreeNode<Int>) -> node.data != 0;
trace(collection.get([0, 1]).data + " == " + 2);
trace(collection.get([1, 1]).data + " == " + 5);

collection.set([0, 0], new TreeNode(4));
trace(collection.get([0, 0]).data + " == " + 4);

collection.set([1, 1], new TreeNode(100)); //ArrayHierarchicalCollection.hx:269: characters 19-46 : Uncaught exception Negative array index: -1
trace(collection.get([1, 1]).data + " == " + 100);

collection.filterFunction = null;
trace(collection.get([1, 1]).data + " == " + 3);
```

I was trying to prove it'd write to the unfiltered `[1, 1]` location, but it didn't even get that far.