### PR TITLE
Bug fix: `Collection.set()` deletes a value if a sort function exists.

### DIFF
--- a/src/feathers/data/ArrayCollection.hx
+++ b/src/feathers/data/ArrayCollection.hx
@@ -240,7 +240,7 @@ class ArrayCollection<T> extends EventDispatcher implements IFlatCollection<T> i
 				this._filterAndSortData.remove(oldItem);
 				// then try to figure out where the new item goes when inserted
 				var sortedIndex = this.getSortedInsertionIndex(item);
-				this._filterAndSortData[sortedIndex] = item;
+				this._filterAndSortData.insert(sortedIndex, item);
 				FlatCollectionEvent.dispatch(this, FlatCollectionEvent.REPLACE_ITEM, index, item, oldItem);
 				FeathersEvent.dispatch(this, Event.CHANGE);
 				return;

--- a/src/feathers/data/ArrayHierarchicalCollection.hx
+++ b/src/feathers/data/ArrayHierarchicalCollection.hx
@@ -293,7 +293,7 @@ class ArrayHierarchicalCollection<T> extends EventDispatcher implements IHierarc
 				// then try to figure out where the new item goes when inserted
 				var wrappedItem = this.createFilterAndSortItem(value);
 				var sortedIndex = this.getSortedInsertionIndex(filteredOrSortedBranchChildren, wrappedItem);
-				filteredOrSortedBranchChildren[sortedIndex] = wrappedItem;
+				filteredOrSortedBranchChildren.insert(sortedIndex, wrappedItem);
 				HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.REPLACE_ITEM, location, value, oldItem);
 				FeathersEvent.dispatch(this, Event.CHANGE);
 				return;

--- a/src/feathers/data/TreeCollection.hx
+++ b/src/feathers/data/TreeCollection.hx
@@ -277,7 +277,7 @@ class TreeCollection<T> extends EventDispatcher implements IHierarchicalCollecti
 				// then try to figure out where the new item goes when inserted
 				var wrappedItem = this.createFilterAndSortItem(value);
 				var sortedIndex = this.getSortedInsertionIndex(filteredOrSortedBranchChildren, wrappedItem);
-				filteredOrSortedBranchChildren[sortedIndex] = wrappedItem;
+				filteredOrSortedBranchChildren.insert(sortedIndex, wrappedItem);
 				HierarchicalCollectionEvent.dispatch(this, HierarchicalCollectionEvent.REPLACE_ITEM, location, value, oldItem);
 				FeathersEvent.dispatch(this, Event.CHANGE);
 				return;

--- a/src/feathers/data/VectorCollection.hx
+++ b/src/feathers/data/VectorCollection.hx
@@ -247,7 +247,7 @@ class VectorCollection<T> extends EventDispatcher implements IFlatCollection<T> 
 				}
 				// then try to figure out where the new item goes when inserted
 				var sortedIndex = this.getSortedInsertionIndex(item);
-				this._filterAndSortData[sortedIndex] = item;
+				this._filterAndSortData.insertAt(sortedIndex, item);
 				FlatCollectionEvent.dispatch(this, FlatCollectionEvent.REPLACE_ITEM, index, item, oldItem);
 				FeathersEvent.dispatch(this, Event.CHANGE);
 				return;


### PR DESCRIPTION
The intent of this code seems to be "delete it from its old index, then insert it at its new index." But instead of inserting, it would overwrite the new index, and the array would end up shorter by 1. Unless the new index happened to be at the end of the array, which might be how it passed testing.